### PR TITLE
Auto-delete packages from the package manager when agent instances are deleted

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# Package manager
+packages/
+
 # Databases
 media/
 *.sqlite3


### PR DESCRIPTION
Note that we can't delegate the deletion to `packages.py` because then we'd have circular imports. The implication seems to be that we should decouple the two later on, so that packages.py just returns a dictionary or something that can then be used to build agents.